### PR TITLE
修正dubbo路由匹配算法的bug

### DIFF
--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/router/condition/ConditionRouter.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/router/condition/ConditionRouter.java
@@ -214,20 +214,32 @@ public class ConditionRouter implements Router, Comparable<Router> {
     private static final class MatchPair {
         final Set<String> matches = new HashSet<String>();
         final Set<String> mismatches = new HashSet<String>();
+        /**
+         * 根据输入的值判断是否匹配
+         * @param value
+         * @param param
+         * @return
+         */
         public boolean isMatch(String value, URL param) {
+            //判断不匹配条件，满足不匹配条件，返回false
             for (String mismatch : mismatches) {
                 if (UrlUtils.isMatchGlobPattern(mismatch, value, param)) {
                     return false;
                 }
             }
+            //如果没有满足不匹配条件，并且没有设置匹配条件，返回true
             if(mismatches.size() > 0 && matches.size() == 0){
                 return true;
             }
+            //判断匹配条件，满足匹配条件，返回true
             for (String match : matches) {
                 if (UrlUtils.isMatchGlobPattern(match, value, param)) {
                     return true;
                 }
             }
+            //到这里只会有2种情况
+            //1、没有设置匹配条件，也没有设置不匹配条件
+            //2、没有满足不匹配条件或者没有设置不匹配条件，但不满足匹配条件
             return false;
         }
     }

--- a/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/router/condition/ConditionRouter.java
+++ b/dubbo-cluster/src/main/java/com/alibaba/dubbo/rpc/cluster/router/condition/ConditionRouter.java
@@ -215,17 +215,20 @@ public class ConditionRouter implements Router, Comparable<Router> {
         final Set<String> matches = new HashSet<String>();
         final Set<String> mismatches = new HashSet<String>();
         public boolean isMatch(String value, URL param) {
-            for (String match : matches) {
-                if (! UrlUtils.isMatchGlobPattern(match, value, param)) {
-                    return false;
-                }
-            }
             for (String mismatch : mismatches) {
                 if (UrlUtils.isMatchGlobPattern(mismatch, value, param)) {
                     return false;
                 }
             }
-            return true;
+            if(mismatches.size() > 0 && matches.size() == 0){
+                return true;
+            }
+            for (String match : matches) {
+                if (UrlUtils.isMatchGlobPattern(match, value, param)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
1、改变匹配条件策略，由原来的条件交集改为条件并集，这个策略会影响路由匹配规则
    例如：设置dubbo路由规则->消费者IP地址->匹配：10.1.2.3,10.1.2.4
    按照原来的规则，则不会有IP能够匹配这个条件，修改后10.1.2.3和10.1.2.4都可以匹配
2、不匹配条件策略不变
